### PR TITLE
DOC: clarify r_pred is the predicted absolute residual

### DIFF
--- a/mapie/conformity_scores/bounds/residuals.py
+++ b/mapie/conformity_scores/bounds/residuals.py
@@ -244,7 +244,7 @@ class ResidualNormalisedScore(BaseRegressionScore):
     ) -> NDArray:
         """
         Computes the signed conformity score = (y - y_pred) / r_pred.
-        r_pred being the predicted residual (y - y_pred) of the estimator.
+        r_pred being the predicted residual abs(y - y_pred) of the estimator.
         It is calculated by a model (``residual_estimator_``) that learns
         to predict this residual.
 


### PR DESCRIPTION
# Description

This PR corrects a misleading description in the docstring of the `get_signed_conformity_scores` function within [`mapie/conformity_scores/bounds/residuals.py`](https://github.com/scikit-learn-contrib/MAPIE/blob/9093a3404b5bc620eaf6871372c42d567b6acd66/mapie/conformity_scores/bounds/residuals.py#L247).

The previous docstring incorrectly stated that the `r_pred` parameter was the predicted signed residual `(y - y_pred)`. In reality, the underlying model (`residual_estimator_`) predicts the absolute residual. This change updates the docstring to `abs(y - y_pred)` to accurately reflect the model's behavior and prevent confusion for users and developers. It also coordinates with the docstring in [this line](https://github.com/scikit-learn-contrib/MAPIE/blob/9093a3404b5bc620eaf6871372c42d567b6acd66/mapie/conformity_scores/bounds/residuals.py#L21).